### PR TITLE
✨ [channels] Support callbacks in select

### DIFF
--- a/channels/src/index.spec.ts
+++ b/channels/src/index.spec.ts
@@ -143,7 +143,7 @@ describe('channels', () => {
   })
 
   it('should select 2', async () => {
-    async function* test() {
+    function* test() {
       const ch1 = yield chan()
       const ch2 = yield chan()
 
@@ -170,5 +170,33 @@ describe('channels', () => {
     }
 
     await cllr.call(test)
+  })
+
+  it('should select with callbacks', async () => {
+    let sent
+    let received
+
+    function* test() {
+      const ch1 = yield chan()
+      const ch2 = yield chan()
+      const ch3 = yield chan()
+
+      yield fork(function* () {
+        yield select(
+          [send(ch2, 'ch2'), () => { sent = 'ch2' }],
+          [send(ch3, 'ch3'), () => { sent = 'ch3' }],
+        )
+      })
+
+      yield select(
+        [recv(ch1), function* (v) { received = v }],
+        [recv(ch2), function* (v) { received = v }],
+      )
+    }
+
+    await cllr.call(test)
+
+    expect(sent).toBe('ch2')
+    expect(received).toBe('ch2')
   })
 })

--- a/channels/src/index.ts
+++ b/channels/src/index.ts
@@ -1,4 +1,4 @@
-import { GeneratorFunction, Plugin, OperationObject, delegate, execute, isGenerator, isOfKind } from '@cuillere/core'
+import { Plugin, OperationObject, delegate, execute, isGenerator, isOfKind } from '@cuillere/core'
 
 const namespace = '@cuillere/channels'
 
@@ -59,8 +59,8 @@ export function channelsPlugin(): Plugin<ChannelsContext> {
       },
 
       async* select({ cases }: Select, ctx) {
-        const simpleCases = cases.filter(isSimpleCase)
-        const indexes = new Map(cases.map((caze, i) => [caze, i]))
+        const simpleCases = cases.map(caze => (isCallbackCase(caze) ? caze[0] : caze))
+        const indexes = new Map(simpleCases.map((caze, i) => [caze, i]))
         const callbacks = new Map(cases.filter(isCallbackCase))
 
         const readyCases = simpleCases.filter((caze) => {
@@ -278,7 +278,7 @@ const DEFAULT = Symbol('DEFAULT')
 
 export type SimpleCase = Send | Recv | typeof DEFAULT
 
-export type CallbackCase = [SimpleCase, GeneratorFunction]
+export type CallbackCase = [SimpleCase, (...args: any[]) => any]
 
 export type Case = SimpleCase | CallbackCase
 

--- a/channels/src/index.ts
+++ b/channels/src/index.ts
@@ -1,4 +1,4 @@
-import { GeneratorFunction, Plugin, OperationObject, call, delegate, isOfKind, isGenerator, execute } from '@cuillere/core'
+import { GeneratorFunction, Plugin, OperationObject, delegate, execute, isGenerator, isOfKind } from '@cuillere/core'
 
 const namespace = '@cuillere/channels'
 


### PR DESCRIPTION
Example from envelope:

```js
yield select(
  [recv(this.register), function* (c: Connection) {
    this.clients.set(c.conn, c.username)
    this.logger.info('client connection registered')
    yield send(this.broadcast, `${c.username} joined envelope\n`)
    yield fork(this.handle(c))
  }],
  [recv(this.broadcast), (msg: string) => {
    for (const conn of this.clients.keys()) {
      conn.write(msg, err => {
        if (err) this.logger.error('sending message failed: %s', err)
      })
    }
  }],
  [recv(this.unregister), (conn: net.Socket) => {
    this.clients.delete(conn)
    this.logger.info('client connection unregistered')
  }],
)
```

Before:

```js
const [i, v] = yield select(
  recv(this.register),
  recv(this.broadcast),
  recv(this.unregister),
)

switch (i) {
case 0: const c = v as Connection
  this.clients.set(c.conn, c.username)
  this.logger.info('client connection registered')
  yield send(this.broadcast, `${c.username} joined envelope\n`)
  yield fork(this.handle(c))
  break

case 1: const msg = v as string
  for (const conn of this.clients.keys()) {
    conn.write(msg, err => {
      if (err) this.logger.error('sending message failed: %s', err)
    })
  }
  break

case 2: const conn = v as net.Socket
  this.clients.delete(conn)
  this.logger.info('client connection unregistered')
}
```

Pros:
 - avoids having to `select` then `switch`.
 - avoids `break`
 - Both generator and classic callbacks are supported

Cons:
 - The syntax...
 - Impossible to shortcut return the main function from a case