### PR TITLE
👷 CI: Setup cache for yarn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,18 @@ jobs:
         with:
           node-version: ${{matrix.node-version}}
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{steps.yarn-cache-dir-path.outputs.dir}}
+          key: node-${{matrix.node-version}}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            node-${{matrix.node-version}}-yarn-
+
       - name: Install dependencies
         run: yarn --frozen-lockfile
 


### PR DESCRIPTION
Wins approximately 30 seconds.
Before: 50+ seconds installing dependencies
Now:
 - < 5 seconds restoring cache
 - < 15 seconds installing dependencies
 - < 5 seconds