### PR TITLE
:sparkles: Improve @cuillere/envelop

### DIFF
--- a/packages/envelop/src/envelop.ts
+++ b/packages/envelop/src/envelop.ts
@@ -74,6 +74,7 @@ const contextPlugin: Plugin<ContextOperations> = {
 
   handlers: {
     * get({ field }, { graphQLContext }) {
+      if (!graphQLContext) throw new Error('getContext() must not be used outside of resolvers')
       if (!field) return graphQLContext
       return graphQLContext[field]
     },


### PR DESCRIPTION
 - Additional cuillere plugins are registered with `useCuillerePlugins()` envelop plugin
 - Allow reading GraphQL context from anywhere in the resolvers using `getContext()`