### PR TITLE
🩹 Fix union type

### DIFF
--- a/server/src/wrap-field-resolvers.ts
+++ b/server/src/wrap-field-resolvers.ts
@@ -55,11 +55,16 @@ function isResolverOptions(value: any): value is IResolverOptions {
 }
 
 function mapResolverOption(value: IResolverOptions) {
-  return {
+  const result = {
     ...value,
-    resolve: value.resolve ? wrapFieldResolver(value.resolve) : value.resolve,
-    subscribe: value.subscribe ? wrapFieldResolver(value.subscribe) : value.subscribe,
   }
+  if (result.resolve) {
+    result.resolve = wrapFieldResolver(value.resolve)
+  }
+  if (result.subscribe) {
+    result.subscribe = wrapFieldResolver(value.subscribe)
+  }
+  return result
 }
 
 function isEnumResolver(value: any): value is IEnumResolver {


### PR DESCRIPTION
Cuillere server tries to wrap the resolve field of all GraphQL types. If the type resolver does not have a resolve field, for example because it is a union type, Cuillere creates one with the value undefined. This triggers an error down the line in graphql-tools, because the latter inspect the resolver using Object.keys and rejects undefined fields. This PR fixes the Cuillere behavior by preventing it to add an undefined resolve field if the type resolver does not already have one.